### PR TITLE
added correct links for navbar/landing page

### DIFF
--- a/app/imports/ui/components/NavBar.jsx
+++ b/app/imports/ui/components/NavBar.jsx
@@ -20,7 +20,7 @@ const NavBar = () => {
         <Navbar.Brand
           id={COMPONENT_IDS.NAVBAR_LANDING_PAGE}
           as={NavLink}
-          to={currentUser ? '/dashboard' : '/'}
+          to="/"
         >
           <Image className="navbar-logo" alt="spire logo" src="/images/inspire.gif" />
         </Navbar.Brand>

--- a/app/imports/ui/layouts/App.jsx
+++ b/app/imports/ui/layouts/App.jsx
@@ -32,6 +32,7 @@ import Page2503 from '../pages/2503';
 
 /** Top-level layout component for this application. Called in imports/startup/client/startup.jsx. */
 const App = () => {
+  // eslint-disable-next-line no-unused-vars
   const { ready, isLogged } = useTracker(() => {
     const rdy = Roles.subscription.ready();
     return {
@@ -44,7 +45,7 @@ const App = () => {
       <div className="d-flex flex-column min-vh-100">
         <NavBar />
         <Routes>
-          <Route exact path="/" element={isLogged ? <Dashboard /> : <Landing />} />
+          <Route exact path="/" element={<Landing />} />
           <Route path="/contact" element={<ContactUs />} />
           <Route path="/about" element={<AboutUs />} />
           <Route path="/signin-signup" element={<SignInSignUpPage />} />
@@ -81,7 +82,7 @@ const App = () => {
 const ProtectedRoute = ({ children }) => {
   const isLogged = Meteor.userId() !== null;
   console.log('ProtectedRoute', isLogged);
-  return isLogged ? children : <Navigate to="/signin" />;
+  return isLogged ? children : <Navigate to="/signin-signup?form=signin" />;
 };
 
 /**
@@ -92,7 +93,7 @@ const ProtectedRoute = ({ children }) => {
 const AdminProtectedRoute = ({ ready, children }) => {
   const isLogged = Meteor.userId() !== null;
   if (!isLogged) {
-    return <Navigate to="/signin" />;
+    return <Navigate to="/signin-signup?form=signin" />;
   }
   if (!ready) {
     return <LoadingSpinner />;

--- a/app/imports/ui/pages/Landing.jsx
+++ b/app/imports/ui/pages/Landing.jsx
@@ -26,7 +26,11 @@ const Landing = () => {
 
   // Handler to navigate to the sign-in page
   const handleGetStartedClick = () => {
-    navigate('/signin-signup?form=signin'); // Replace '/signin' with the correct path for your sign-in page
+    if (currentUser) {
+      navigate('/dashboard'); // Navigate to the dashboard if the user is signed in
+    } else {
+      navigate('/signin-signup?form=signin'); // Navigate to the sign-in page if the user is not signed in
+    }
   };
 
   // const featureLink = currentUser ? '/dashboard' : '/signin-signup?form=signin';


### PR DESCRIPTION
1. Originally, the user couldn't go to the landing page if signed in and could only go to dashboard page. this is inconvenient, and the user can only access the links in the carousel if signed in anyways (meaning that if they weren't signed in, this would redirect to the sign in page).

2. I updated the sign in page link in the app.jsx because it was using the old sign in link that didn't work anymore.